### PR TITLE
Load Lists and List items from the backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,6 @@
   },
   "devDependencies": {
     "prettier": "^2.2.1"
-  }
+  },
+  "proxy": "http://localhost:8888"
 }

--- a/src/AmplifyAuthProvider.js
+++ b/src/AmplifyAuthProvider.js
@@ -21,7 +21,10 @@ export function getSignoutComponent() {
 export function listenForAuthStateChange(onSignIn, onSignOut) {
   onAuthUIStateChange((nextAuthState, authData) => {
     if (nextAuthState === AuthState.SignedIn) {
-      onSignIn(authData);
+      onSignIn(
+        authData,
+        authData.getSignInUserSession().getIdToken().getJwtToken()
+      );
     } else if (nextAuthState === AuthState.SignedOut) {
       onSignOut(authData);
     }

--- a/src/YataClient.js
+++ b/src/YataClient.js
@@ -1,0 +1,51 @@
+let jwt = null;
+export function setAuthToken(token) {
+  jwt = token;
+}
+
+export async function GetItems(listID) {
+  return call("/lists/" + listID + "/items", "GET");
+}
+
+export async function GetLists() {
+  return call("/lists", "GET");
+}
+
+export async function DescribeList(listID) {
+  return call("/lists/" + listID + "/", "GET");
+}
+
+async function call(endpoint, method) {
+  return fetch(endpoint, {
+    method: method,
+    headers: {
+      Authorization: getAuthHeader(),
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    // TODO: decode the body as json and then use Code and Message from error struct
+    throw new HttpResponseError(response.status, response.statusText);
+  });
+}
+
+function getAuthHeader() {
+  if (jwt === null) {
+    throw new HttpResponseError(
+      new Response(new Blob(), {
+        status: 403,
+        statusText: "User is not authenticated",
+      })
+    );
+  }
+  return "Bearer " + jwt;
+}
+
+export class HttpResponseError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = code;
+    this.message = message;
+  }
+}

--- a/src/components/AllListsView.js
+++ b/src/components/AllListsView.js
@@ -1,12 +1,58 @@
+import { GetLists } from "../YataClient";
+import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+
 /**
  * AllListsView is the view which shows all the lists that a user has
  */
 function AllListsView() {
-  return (
-    <div>
-      This will be the component that displays all the lists that a user has
-    </div>
-  );
+  const [state, setState] = useState({
+    error: null,
+    loading: true,
+    lists: null,
+  });
+
+  useEffect(() => {
+    GetLists()
+      .then((data) => {
+        setState({ error: null, loading: false, lists: data.Lists });
+      })
+      .catch((error) => {
+        setState({
+          error: { code: error.name, message: error.message },
+          loading: false,
+          lists: null,
+        });
+      });
+  }, []);
+
+  let content;
+  if (state.error !== null) {
+    content = (
+      <div>
+        <b>Sorry, something went wrong</b>
+        <br />
+        <small>
+          Error {state.error.code}: {state.error.message}
+        </small>
+      </div>
+    );
+  } else if (state.loading) {
+    content = <div>Loading...</div>;
+  } else {
+    const allLists = state.lists.map((list) => (
+      <div key={list.ListID} class="tile is-parent is-4">
+        <article class="tile is-child has-background-primary box">
+          <Link class="title" to={"/list/" + list.ListID}>
+            {list.Title}
+          </Link>
+        </article>
+      </div>
+    ));
+    content = <div class="tile is-ancestor is-flex-wrap-wrap">{allLists}</div>;
+  }
+
+  return <div>{content}</div>;
 }
 
 export default AllListsView;

--- a/src/components/ListDetailsView.js
+++ b/src/components/ListDetailsView.js
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
+import { DescribeList, GetItems } from "../YataClient";
 
 /**
  * ListDetailsView is the view which shows the details for a list and all its items
@@ -7,12 +8,103 @@ import { useParams } from "react-router-dom";
 function ListDetailsView() {
   let { id } = useParams();
 
+  const [listState, setListState] = useState({
+    details: null,
+    loading: true,
+    error: null,
+  });
+  const [itemsState, setItemsState] = useState({
+    items: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    GetItems(id)
+      .then((data) => {
+        setItemsState({
+          items: data.Items,
+          loading: false,
+          error: null,
+        });
+      })
+      .catch((error) => {
+        console.error("Error getting items ", error);
+        setItemsState({
+          items: null,
+          loading: false,
+          error: { code: error.name, message: error.message },
+        });
+      });
+
+    DescribeList(id)
+      .then((data) => {
+        setListState({
+          details: data.List,
+          loading: false,
+          error: null,
+        });
+      })
+      .catch((error) => {
+        console.error("Error describing list ", error);
+        setListState({
+          details: null,
+          loading: false,
+          error: { code: error.name, message: error.message },
+        });
+      });
+  }, [id]);
+
+  //TODO: error
+  if (listState.error !== null) {
+    return renderError(listState.error);
+  }
+
+  if (itemsState.error !== null) {
+    return renderError(itemsState.error);
+  }
+
+  let content;
+  if (itemsState.loading || listState.loading) {
+    content = <div>Loading...</div>;
+  } else {
+    content = (
+      <div>
+        <ListDetails list={listState.details} loading={listState.loading} />
+        <ListItems items={itemsState.items} loading={itemsState.loading} />
+      </div>
+    );
+  }
+
+  return <div class="content">{content}</div>;
+}
+
+function renderError(error) {
   return (
     <div>
-      <h3>ID: {id}</h3>
-      This will be the page that displays all the items and details for a list
+      <h1 class="title">Sorry! Something went wrong</h1>
+      <p>
+        Error {error.code}: {error.message}
+      </p>
     </div>
   );
+}
+
+function ListDetails(props) {
+  return <h1 class="title">{props.list.Title}</h1>;
+}
+
+function ListItems(props) {
+  let content;
+  if (props.items.length === 0) {
+    content = <div>There are no items!</div>;
+  } else {
+    content = props.items.map((item) => (
+      <li key={item.ItemID}>{item.Content}</li>
+    ));
+  }
+
+  return <ul>{content}</ul>;
 }
 
 export default ListDetailsView;

--- a/src/hooks/UseAuth.js
+++ b/src/hooks/UseAuth.js
@@ -1,4 +1,5 @@
 import React, { useContext, createContext, useState } from "react";
+import { setAuthToken } from "../YataClient";
 
 const authContext = createContext();
 
@@ -20,10 +21,13 @@ function useProvideAuth() {
 
   const signout = (userData) => {
     setUser(null);
+    setAuthToken(null);
   };
 
-  const signin = (userData) => {
+  const signin = (userData, token) => {
+    //TODO: save the userData and token to browser storage and refresh token as needed
     setUser(userData);
+    setAuthToken(token);
   };
 
   return {


### PR DESCRIPTION
This change fills out the AllListsView and the ListDetailsView pages by
loading the content from the backend.

This also saves the authentication token to be used for API calls and retrives
it using the UseAuth hook.

The client for the API is introduced in YataClient.js. The client is rather
basic right now and just wraps the fetch api calls from the backend. The client
can be extensively further configured in the future in a refactoring once
we understand the use cases for the client better.